### PR TITLE
[Auto-PR] Adding Repository Maintenance workflow

### DIFF
--- a/.github/workflows/repository-maintenance.yml
+++ b/.github/workflows/repository-maintenance.yml
@@ -1,0 +1,13 @@
+name: Repository Maintenance
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  maintenance_workflow:
+    uses: getyourguide/java-actions/.github/workflows/reusable-java-repo-maintenance-workflow.yml@v1.0.9
+    name: Maintenance
+    secrets:
+      CODEARTIFACT_AUTH_TOKEN: ${{ secrets.CODEARTIFACT_AUTH_TOKEN }}
+


### PR DESCRIPTION
### Description

This PR adds a repository maintenance workflow, which contains a step to publish dependencies from gradle 
services to GitHub API. This enabled reporting of security vulnerabilities in dependencies.

It also contains additional steps, therefore you can remove those ones from the existing workflows.
* credential-scan
* dependency-submission
* validate catalog-info

Please merge the PR and keep an eye on the security alerts. If you have any questions, feel free to reach out
to #guild-java. 

This PR will be automatically merged in a week if not actioned.
