### PR TITLE
DEN-4986 [Automatic PR] Add concurrency to workflows

### DIFF
--- a/.github/workflows/repository-maintenance.yml
+++ b/.github/workflows/repository-maintenance.yml
@@ -4,6 +4,10 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   maintenance_workflow:
     runs-on: ubuntu-latest
@@ -26,4 +30,3 @@ jobs:
           CODEARTIFACT_AUTH_TOKEN: ${{ secrets.CODEARTIFACT_AUTH_TOKEN }}
           SCHEMAPI_LOGIN: ${{ secrets.SCHEMAPI_LOGIN }}
           SCHEMAPI_PASSWORD: ${{ secrets.SCHEMAPI_PASSWORD }}
-


### PR DESCRIPTION
This is an automatic PR that adds concurrency to GHA workflows. As an effect there will be at most one running job __in a concurrency group__ (a branch) at any time, default branch excluded.
Optimizations like these are good for making runners available for other jobs, and will be enforced soon.

If you don't agree with these changes leave a review and raise your concern, otherwise please __merge the PR__.
