### PR TITLE
[Hotfix] Pin versions of GH actions

### DIFF
--- a/.github/workflows/repository-maintenance.yml
+++ b/.github/workflows/repository-maintenance.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4.2.1
-      - uses: actions/setup-java@v4.4.0
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.4.0
         name: Setup Java
         with:
           distribution: temurin
           java-version: 17
       - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v4.1.0
+        uses: gradle/actions/dependency-submission@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0
         with:
           gradle-version: wrapper
           dependency-graph: generate-and-submit


### PR DESCRIPTION
This pull request pins the versions of GitHub Actions used in the repository-maintenance workflow to specific commit SHAs instead of floating version tags. This ensures that the CI workflows run with stable, known versions of the actions without unexpected updates.

---

<!-- Automated description preserves everything you've added after the comment above -->

<!--
1. Always set a descriptive title, example: "bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
-->