### PR TITLE
[CODEOWNERS] Replace team tp with clp

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*                                       @getyourguide/tp
+*                                       @getyourguide/clp


### PR DESCRIPTION
Replace team references from `@getyourguide/tp` to `@getyourguide/clp` in the CODEOWNERS file.

**⚠️ Action Required:**
Review and merge this PR to complete the team replacement.

**Note:** This change was made by the [codeowners-rename](https://github.com/getyourguide/actions/tree/main/codeowners-rename) GitHub Action.